### PR TITLE
Remove pub/#[no_mangle] decorators on lang items

### DIFF
--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -39,16 +39,14 @@ use core::{mem, slice};
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[panic_implementation]
-#[no_mangle]
-pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe {
         core::intrinsics::abort();
     }
 }
 
 #[alloc_error_handler]
-#[no_mangle]
-pub extern "C" fn oom(_: core::alloc::Layout) -> ! {
+fn oom(_: core::alloc::Layout) -> ! {
     unsafe {
         core::intrinsics::abort();
     }


### PR DESCRIPTION
I was poking around this wasm project to double check that the wasm module is
appropriately sized, but to my surprise there were some stray symbols exported
from the wasm module! Specifically the wasm module currently exports
`rust_begin_unwind` and `rust_oom` symbols, but neither of these should be
exported.

The `#[panic_implementation]` and `#[alloc_error_handler]` attributes should
render the `pub` and `#[no_mangle]` annotations unnecessary, however, and the
compiler manages the symbol business internally with the wrapper it generates.