### PR TITLE
feat(wasm) Optimise performance

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -16,4 +16,4 @@ debug = true
 
 [dependencies]
 gutenberg_post_parser = { path = "../../cargo/no_std/", version = "=0.14.0" }
-wee_alloc = { version = "0.4.2" }
+wee_alloc = "0.4.2"

--- a/bindings/wasm/bin/gutenberg_post_parser.mjs
+++ b/bindings/wasm/bin/gutenberg_post_parser.mjs
@@ -1,6 +1,5 @@
 function writeString(module, string_buffer, string_buffer_capacity) {
     const pointer = module.alloc(string_buffer_capacity);
-
     const buffer = new Uint8ClampedArray(module.memory.buffer, pointer);
 
     for (let i = 0; i < string_buffer_capacity; i++) {
@@ -11,10 +10,8 @@ function writeString(module, string_buffer, string_buffer_capacity) {
 }
 
 function readNodes(module, start_pointer) {
-    console.log('read nodes', start_pointer);
-
     const buffer_properties = new Uint32Array(module.memory.buffer, start_pointer, 2);
-    const buffer_capacity = buffer_properties[0];
+    const buffer_capacity = buffer_properties[0] / 4;
     const buffer_length = buffer_properties[1] / 4;
     const payload_pointer = start_pointer + 8;
 

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -62,7 +62,7 @@ pub enum c_void {
 
 #[no_mangle]
 pub extern "C" fn alloc(capacity: usize) -> *mut u8 {
-    let mut buffer: Vec<u8> = Vec::with_capacity(capacity);
+    let mut buffer = Vec::with_capacity(capacity);
     let pointer = buffer.as_mut_ptr();
     mem::forget(buffer);
 
@@ -72,7 +72,7 @@ pub extern "C" fn alloc(capacity: usize) -> *mut u8 {
 #[no_mangle]
 pub extern "C" fn dealloc(pointer: *mut u8, capacity: usize) {
     unsafe {
-        let _: Vec<u8> = Vec::from_raw_parts(pointer, 0, capacity);
+        let _ = Vec::from_raw_parts(pointer, 0, capacity);
     }
 }
 
@@ -93,9 +93,9 @@ macro_rules! push_u32_as_u8s {
 }
 
 #[no_mangle]
-pub extern "C" fn root(pointer: *mut u8, length: usize) -> *mut u8 {
+pub extern "C" fn root(pointer: *mut u8, length: usize) -> *const u8 {
     let input = unsafe { slice::from_raw_parts(pointer, length) };
-    let mut output = vec![0; 8];
+    let mut output: Vec<u8> = vec![0; 8];
 
     if let Ok((_remaining, nodes)) = gutenberg_post_parser::root(input) {
         let nodes_length = nodes.len() as u32;
@@ -123,7 +123,7 @@ pub extern "C" fn root(pointer: *mut u8, length: usize) -> *mut u8 {
     output[6] = ((output_length >> 16) & 0xff) as u8;
     output[7] = ((output_length >> 24) & 0xff) as u8;
 
-    let pointer = output.as_mut_ptr();
+    let pointer = output.as_ptr();
 
     mem::forget(output);
 

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -61,55 +61,47 @@ pub enum c_void {
 }
 
 #[no_mangle]
-pub extern "C" fn alloc(capacity: usize) -> *mut c_void {
-    let mut buffer = Vec::with_capacity(capacity);
+pub extern "C" fn alloc(capacity: usize) -> *mut u8 {
+    let mut buffer: Vec<u8> = Vec::with_capacity(capacity);
     let pointer = buffer.as_mut_ptr();
     mem::forget(buffer);
 
-    pointer as *mut c_void
+    pointer
 }
 
 #[no_mangle]
-pub extern "C" fn dealloc(pointer: *mut c_void, capacity: usize) {
+pub extern "C" fn dealloc_u8(pointer: *mut u8, capacity: usize) {
     unsafe {
-        let _ = Vec::from_raw_parts(pointer, 0, capacity);
+        let _: Vec<u8> = Vec::from_raw_parts(pointer, 0, capacity);
     }
 }
 
-macro_rules! push_u32_as_u8s {
-    ($u32:ident in $output:ident) => (
-        $output.push((($u32 >> 24) & 0xff) as u8);
-        $output.push((($u32 >> 16) & 0xff) as u8);
-        $output.push((($u32 >>  8) & 0xff) as u8);
-        $output.push((($u32      ) & 0xff) as u8);
-    )
+#[no_mangle]
+pub extern "C" fn dealloc_u32(pointer: *mut u32, capacity: usize) {
+    unsafe {
+        let _: Vec<u32> = Vec::from_raw_parts(pointer, 0, capacity);
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn root(pointer: *mut u8, length: usize) -> *mut u8 {
+pub extern "C" fn root(pointer: *mut u8, length: usize) -> *mut u32 {
     let input = unsafe { slice::from_raw_parts(pointer, length) };
-    let mut output = vec![0; 4];
+    let mut output = vec![0; 1];
 
     if let Ok((_remaining, nodes)) = gutenberg_post_parser::root(input) {
         let nodes_length = nodes.len() as u32;
-        let mut utf16_offset = 0;
         let mut remaining_input = input;
+        let mut utf16_offset = 0;
 
         output.reserve(nodes_length as usize * 12);
-
-        push_u32_as_u8s!(nodes_length in output);
+        output.push(nodes_length);
 
         for node in nodes {
             remaining_input = into_bytes(&node, &remaining_input, &mut utf16_offset, &mut output);
         }
     }
 
-    let output_length = output.len() as u32;
-
-    output[0] = ((output_length >> 24) & 0xff) as u8;
-    output[1] = ((output_length >> 16) & 0xff) as u8;
-    output[2] = ((output_length >>  8) & 0xff) as u8;
-    output[3] = ((output_length      ) & 0xff) as u8;
+    output[0] = output.len() as u32;
 
     let pointer = output.as_mut_ptr();
 
@@ -118,18 +110,19 @@ pub extern "C" fn root(pointer: *mut u8, length: usize) -> *mut u8 {
     pointer
 }
 
-fn into_bytes<'a>(node: &Node<'a>, mut remaining_input: &'a [u8], utf16_offset: &mut u32, output: &mut Vec<u8>) -> &'a [u8] {
+fn into_bytes<'a>(node: &Node<'a>, mut remaining_input: &'a [u8], utf16_offset: &mut u32, output: &mut Vec<u32>) -> &'a [u8] {
     match *node {
         Node::Block { name, attributes, ref children } => {
-            // Push node type.
-            output.push(1u8);
+            let node_type = 1u32;
+            
+            output.push(node_type);
 
             let name_length = name.0.len() + name.1.len() + 1;
 
-            output.push(name_length as u8);
-            output.extend(name.0);
-            output.push(b'/');
-            output.extend(name.1);
+            output.push(name_length as u32);
+            output.extend(name.0.iter().map(|c: &u8| *c as u32));
+            output.push(b'/' as u32);
+            output.extend(name.1.iter().map(|c: &u8| *c as u32));
 
             let input_offset: usize = remaining_input.offset(&name.1) + name.1.len() + 1;
             remaining_input = &remaining_input[input_offset..];
@@ -157,12 +150,9 @@ fn into_bytes<'a>(node: &Node<'a>, mut remaining_input: &'a [u8], utf16_offset: 
                 }
             };
 
-            push_u32_as_u8s!(attributes_offset in output);
-            push_u32_as_u8s!(attributes_length in output);
-
-            let number_of_children = children.len();
-
-            output.push(number_of_children as u8);
+            output.push(attributes_offset);
+            output.push(attributes_length);
+            output.push(children.len() as u32);
 
             for child in children {
                 remaining_input = into_bytes(&child, remaining_input, utf16_offset, output);
@@ -172,8 +162,9 @@ fn into_bytes<'a>(node: &Node<'a>, mut remaining_input: &'a [u8], utf16_offset: 
         },
 
         Node::Phrase(phrase) => {
-            // Push node type.
-            output.push(2u8);
+            let node_type = 2u32;
+
+            output.push(node_type);
 
             let mut input_offset: usize = remaining_input.offset(&phrase);
 
@@ -185,9 +176,8 @@ fn into_bytes<'a>(node: &Node<'a>, mut remaining_input: &'a [u8], utf16_offset: 
             input_offset += phrase.len();
             remaining_input = &remaining_input[input_offset..];
 
-            // Push phrase.
-            push_u32_as_u8s!(phrase_offset in output);
-            push_u32_as_u8s!(phrase_length in output);
+            output.push(phrase_offset);
+            output.push(phrase_length);
 
             remaining_input
         }


### PR DESCRIPTION
This PR contains few optimisation to get improve performance, but the most important one is the change from `Uint8Array` to `Uint32Array` in the JS land. Indeed, commit after commit, the Rust code now almost only emits “offsets” encoded on 4-bytes (so UTF-32). On the JS side, instead of accessing the buffer 4 times each time and using a `u8s_to_u32` function, I tried to change the buffer view from `Uint8Array` to `Uint32Array`. And it helps! It saves around 10% of the CPU time, not bad.

However, the memory does not longer deallocate and I don't understand why. When running a benchmark, the memory grows until the “VM crashed” (numbers go negative).

The PR, in its current state, contains the debugging statements. The problem can be viewed by running:

```sh
$ cd bindings/wasm
$ just build-wasm
$ ./bin/gutenberg-post-parser -j <( echo -n '<!-- wp:foo /-->' )
…
16
Uint8Array [ 60, 33, 45, 45, 32, 119, 112, 58, 102, 111, 111, 32, 47, 45, 45, 62 ]
Uint8Array [ 0, 224, 17, 0, 32, 119, 112, 58, 102, 111, 111, 32, 47, 45, 45, 62 ]
[
    {
        "name": "core/foo",
        "attributes": null,
        "children": []
    }
]
```

The first `Uint8Array` contains the `memory.buffer` of the WASM instance before calling `dealloc_u8`.

The second `Uint8Array` contains the `memory.buffer` of the WASM instance after calling `dealloc_u8`.

I expect to get a line of zeros. Any clues @fitzgen @alexcrichton?